### PR TITLE
mag and abs not correct definition

### DIFF
--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -60,7 +60,7 @@ namespace Utility {
     }
 
     double abs(complex_d& c){
-        return c.real() * c.real() + c.imag() * c.imag();
+        return sqrt(c.real() * c.real() + c.imag() * c.imag());
     }
 
     double mag(complex_d& c){

--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -59,12 +59,12 @@ namespace Utility {
         }
     }
 
-    double mag(complex_d& c){
+    double abs(complex_d& c){
         return c.real() * c.real() + c.imag() * c.imag();
     }
 
-    double abs(complex_d& c){
-        return sqrt(c.real() * c.real() + c.imag() + c.imag());
+    double mag(complex_d& c){
+        return sqrt(c.real() * c.real() + c.imag() * c.imag());
     }
 
     complex_d omega(float p, float q){


### PR DESCRIPTION
magnitude = |z| = sqrt(a.real^2 + b.imag^2) 
abs =  |z| = sqrt(a.real^2 + b.imag^2)
but in your code this is backward.  Also abs and magnitude is the same for complex numbers
And was not correct formula "+" instead "*"